### PR TITLE
fetch() now resolves with null message if there are no messages

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,7 +92,7 @@ var promiseCallback = function(resolve, reject) {
         reject(err)
       }
       else if (!data.Messages) {
-        reject()
+        resolve(null)
       } else { // success
         try {
           resolve(

--- a/test/unit/unit.js
+++ b/test/unit/unit.js
@@ -131,6 +131,10 @@ describe('qDog', function() {
         ]
       }
 
+    var inputDataEmpty =
+      {
+      }
+
     var resolveData =
         { id: 'abc1234'
         , body: {test: 'data'}
@@ -150,6 +154,21 @@ describe('qDog', function() {
         .catch(function(data) {
           assert.equal(data, "Malformed JSON in response message")
           done()
+        })
+
+    })
+
+    it('should resolve with null if no messages are available', function(done) {
+
+      stub.callsArgWith(1, null, inputDataEmpty)
+
+      qDog.fetch()
+        .then(function(data) {
+          assert.equal(data, null)
+          done()
+        })
+        .catch(function(err) {
+          done(new Error(err))
         })
 
     })


### PR DESCRIPTION
Allow fetch() to resolve as null instead of throwing an error when there are no messages currently available in the queue.

NOTE: Since this is an API change, we should bump the version to at least 1.1.0.

Reviewer: @lrvick 