### PR TITLE
Add options parameter to toss(); add options.delaySeconds

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,12 +56,27 @@ var QDog = module.exports = function(config) {
     })
 }
 
+/**
+ * Add a message to the queue.
+ *
+ * @param {Object} message
+ * @param {Object} [options]
+ * @param {number} [options.delaySeconds] - delay
+ *   processing of the message for this number of seconds;
+ *   max 900 for SQS queues
+ */
+QDog.prototype.toss = function(message, options) {
+  options = options || {};
 
-QDog.prototype.toss = function(message) {
+  var delaySeconds = options.delaySeconds || 0;
+
+  if (delaySeconds < 0) throw new Error('invalid delaySeconds');
+
   var _this = this
   var params =
     { MessageBody: _toJSONString(message)
       , QueueUrl: _this.config.queueUrl
+      , DelaySeconds: delaySeconds
     }
 
   return new Promise(function postPromise(resolve, reject) {

--- a/test/unit/unit.js
+++ b/test/unit/unit.js
@@ -106,6 +106,12 @@ describe('qDog', function() {
         })
     })
 
+    it('should throw if delaySeconds is negative', function() {
+      assert.throws(function() {
+        qDog.toss({}, {delaySeconds: -1})
+      })
+    })
+
     var resolveData = {success: 'data'}
 
     promiseTest('toss', stub, resolveData, resolveData, {error: 'data'})


### PR DESCRIPTION
The delaySeconds option allows delaying processing of a message
for up to 900 seconds on SQS. (Not enforced by qdog; we leave it to Amazon to decide how to handle an out-of-range value.)

Reviewers: @lrvick @aheckmann 