### PR TITLE
changed; fetch resolves with an array

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ var promiseCallback = function(resolve, reject) {
   var params = {
     QueueUrl: self.config.queueUrl, /* required */
     AttributeNames: ['All'],
-    MaxNumberOfMessages: 1,
+    MaxNumberOfMessages: self.config.maxMessages || 1,
     WaitTimeSeconds: 20
   };
 
@@ -72,18 +72,24 @@ var promiseCallback = function(resolve, reject) {
     }
 
     if (!data.Messages) {
-      resolve(null);
+      resolve([]);
       return;
     }
 
+    var msgs;
     try {
-      resolve({
-        id: data.Messages[0].ReceiptHandle,
-        body: JSON.parse(data.Messages[0].Body)
+      msgs = data.Messages.map(function(msg) {
+        return {
+          id: msg.ReceiptHandle,
+          body: JSON.parse(msg.Body)
+        };
       });
-    } catch (e) {
-      reject('Malformed JSON in response message');
+    } catch (_) {
+      reject(new Error('Malformed JSON in response message'));
+      return;
     }
+
+    resolve(msgs);
   });
 };
 

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -25,9 +25,9 @@ describe('QDog', function() {
     it('should fetch the item from the SQS queue', function(done) {
       qDog.fetch()
       .then(function(data) {
-        assert(data.id);
-        assert.deepEqual(data.body, testData);
-        messageId = data.id;
+        assert(data[0].id);
+        assert.deepEqual(data[0].body, testData);
+        messageId = data[0].id;
         done();
       });
     });


### PR DESCRIPTION
This change provides support for reading multiple messages
at a time from SQS while providing a consistent API regardless
of configured numMaxMessages.

http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#receiveMessage-property
- fetch() now always resolves with an array
- fetch() resolves with empty array when no messages found
- fetch() supports reading configurable number of messages at a time (numMaxMessages)
- fetch() now rejects with an instanceof Error on JSON parse errors
